### PR TITLE
Read version from pyproject

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,11 @@
 project = 'psyflow'
 copyright = '2025, Zhipeng Cao'
 author = 'Zhipeng Cao'
-release = '0.1.0'
+import os
+import sys
+sys.path.insert(0, os.path.abspath(".."))  # so Sphinx can find your package
+from psyflow._version import read_version
+release = read_version()
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -26,11 +30,6 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 html_theme = 'alabaster'
 html_static_path = ['_static']
-
-
-import os
-import sys
-sys.path.insert(0, os.path.abspath(".."))  # so Sphinx can find your package
 
 # Enable extensions
 extensions = [

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,12 @@ Start with one of the tutorials below or explore the API reference.
 
    modules
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Development
+
+   release
+
 
 Indices and tables
 ==================

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,5 @@
+# Release workflow
+
+1. Update the version number in `pyproject.toml` under the `[project]` section.
+2. Commit the change with a message that includes `[publish]` to trigger the release pipeline.
+3. Build and upload the package as usual.

--- a/psyflow/__init__.py
+++ b/psyflow/__init__.py
@@ -1,7 +1,6 @@
-"""
-psyflow: A utility package for modular PsychoPy experiment development
-"""
-__version__ = "0.1.0"
+"""psyflow: A utility package for modular PsychoPy experiment development."""
+
+from ._version import __version__
 from .BlockUnit import BlockUnit
 from .StimBank import StimBank
 from .SubInfo import SubInfo

--- a/psyflow/_version.py
+++ b/psyflow/_version.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from pathlib import Path
+import re
+
+
+def read_version() -> str:
+    """Return project version from pyproject.toml."""
+    root = Path(__file__).resolve().parent.parent
+    pyproject = root / "pyproject.toml"
+    text = pyproject.read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if not match:
+        raise RuntimeError("Version not found in pyproject.toml")
+    return match.group(1)
+
+
+__version__ = read_version()

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,18 @@
+from pathlib import Path
+import re
 from setuptools import setup, find_packages
+
+
+def read_version() -> str:
+    text = Path(__file__).with_name("pyproject.toml").read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if not match:
+        raise RuntimeError("Version not found in pyproject.toml")
+    return match.group(1)
 
 setup(
     name="psyflow",
-    version="0.1.0",
+    version=read_version(),
     description="A utility package for building modular PsychoPy experiments.",
     author="Zhipeng Cao",
     author_email="zhipeng30@foxmail.com",


### PR DESCRIPTION
## Summary
- centralize package version in `pyproject.toml`
- expose a helper to parse the version
- load the version dynamically in `setup.py`, the package init and docs
- document release workflow

## Testing
- `python -m compileall -q psyflow docs setup.py`

------
https://chatgpt.com/codex/tasks/task_e_6841705088c483248976caf8df51091f